### PR TITLE
Skill fixes freeze and second bullet (#11)

### DIFF
--- a/Library/Alien.asm
+++ b/Library/Alien.asm
@@ -56,16 +56,6 @@ proc PrintAliens
 	call PrintBMP
 	jmp @@continueAlien
 
-@@printFreezeAlien:
-	push [word ptr FAlienFileHandle]
-	push FAlienLength
-	push FAlienHeight
-	push [word ptr bp - 2]
-	push [word ptr bp - 4]
-	push offset FileReadBuffer
-	call PrintBMP
-
-
 @@printBlackAlien:
     ; Print black rectangle for dead aliens:
     push 42
@@ -78,6 +68,16 @@ proc PrintAliens
 	push ax
     push BlackColor
     call PrintColor
+	jmp @@continueAlien
+
+@@printFreezeAlien:
+	push [word ptr FAlienFileHandle]
+	push FAlienLength
+	push FAlienHeight
+	push [word ptr bp - 2]
+	push [word ptr bp - 4]
+	push offset FileReadBuffer
+	call PrintBMP
 
 @@continueAlien:
     pop bx
@@ -718,12 +718,25 @@ KillAlien:
 	add ax, [AliensPrintStartRow]
 	sub ax, 4
 
-	; push 36
-	; push 24
-	; push ax
-	; push dx
-	; push BlueColor
-	; call PrintColor
+	;Splatter Printing Start
+	push [SplatterFileHandle]
+	push SplatterLength
+	push SplatterHeight
+	push [word ptr PlayerBulletLineLocation]
+	push [word ptr PlayerShootingRowLocation]
+	push offset FileReadBuffer
+	call PrintBMP
+
+	push 2
+	call Delay
+
+	push SplatterLength
+	push SplatterHeight
+	push [word ptr PlayerBulletLineLocation]
+	push [word ptr PlayerShootingRowLocation]
+	push BlackColor
+	call PrintColor
+	; Splatter Printing End
 	
 	pop dx
 	pop bx
@@ -897,8 +910,8 @@ proc CheckAndHitAlienSecondary
 	push [SplatterFileHandle]
 	push SplatterLength
 	push SplatterHeight
-	push [word ptr PlayerBulletLineLocation]
-	push [word ptr PlayerShootingRowLocation]
+	push [word ptr SecondaryBulletLineLocation]
+	push [word ptr SecondaryShootingRowLocation]
 	push offset FileReadBuffer
 	call PrintBMP
 
@@ -907,15 +920,15 @@ proc CheckAndHitAlienSecondary
 
 	push SplatterLength
 	push SplatterHeight
-	push [word ptr PlayerBulletLineLocation]
-	push [word ptr PlayerShootingRowLocation]
+	push [word ptr SecondaryBulletLineLocation]
+	push [word ptr SecondaryShootingRowLocation]
 	push BlackColor
 	call PrintColor
 	; Splatter Printing End
 
-	mov [byte ptr PlayerShootingExists], 0
-	mov [word ptr PlayerBulletLineLocation], 0
-	mov [word ptr PlayerShootingRowLocation], 0
+	mov [byte ptr SecondaryShootingExists], 0
+	mov [word ptr SecondaryBulletLineLocation], 0
+	mov [word ptr SecondaryShootingRowLocation], 0
 
     ; Increase score
     inc [byte ptr Score]


### PR DESCRIPTION
* Refactor key input handling in PlayGame procedure to improve readability and add heart regeneration feature

* Test explosion Don't merge

* Address dead aliens printing issue
- Shift the black color by 10 left
- Increase the black color size by 10

* Removed explosion tests

* Fixed readKey loop

* Added laser functionality

* Added AOE attack

* Ignored tasks

* Added secondary bullet

* Fixed secondary bullet affecting the

* Fixed invisible frozen aliens